### PR TITLE
Compile scss to css before publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .idea/
-dist/
+lib/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea/
+dist/
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ node_modules
 .idea
 .DS_Store
 *.log
+.gitignore
+src

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var css = require('./src/styles/styles.scss');
+var css = require('./dist/styles.css');
 
 // media breakpoint - small screen min width
 var smallScreenMin = 768;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var css = require('./dist/styles.css');
+var css = require('./lib/styles.css');
 
 // media breakpoint - small screen min width
 var smallScreenMin = 768;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Official theme for Reapop",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node-sass src/styles/styles.scss -o dist",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -27,5 +29,8 @@
   "homepage": "https://github.com/LouisBarranqueiro/reapop-theme-wybo#readme",
   "peerDependencies": {
     "font-awesome": "^4.6.1"
+  },
+  "devDependencies": {
+    "node-sass": "^3.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node-sass src/styles/styles.scss -o dist",
+    "build": "node-sass src/styles/styles.scss -o lib",
     "prepublish": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Following your comment at #1 I put up this PR. Basically I'm compiling from raw scss to css using `node-sass` using the `prepublish` npm's hook and then I use the compiled css in index.js instead of scss.
